### PR TITLE
Property linking

### DIFF
--- a/app/connectors/ServiceContract.scala
+++ b/app/connectors/ServiceContract.scala
@@ -21,10 +21,13 @@ import org.joda.time.DateTime
 
 case class CapacityDeclaration(capacity: CapacityType, fromDate: DateTime, toDate: Option[DateTime] = None)
 
-case class PropertyLink(uarn: Long, userId: String, capacityDeclaration: CapacityDeclaration,
+case class PropertyLinkRequest(uarn: Long, userId: String, capacityDeclaration: CapacityDeclaration,
                         linkedDate: DateTime, linkBasis: LinkBasis,
                         specialCategoryCode: String, description: String, bulkClassIndicator: String,
-                        pending: Boolean = true)
+                        fileName: String, fileType: String)
+
+case class PropertyLink(uarn: Long, userId: String, description: String, capacityDeclaration: CapacityDeclaration,
+                        linkedDate: DateTime, pending: Boolean)
 
 case class LinkedProperties(added: Seq[PropertyLink], pending: Seq[PropertyLink])
 

--- a/app/connectors/propertyLinking/PropertyLinkConnector.scala
+++ b/app/connectors/propertyLinking/PropertyLinkConnector.scala
@@ -16,7 +16,7 @@
 
 package connectors.propertyLinking
 
-import connectors.{CapacityDeclaration, LinkBasis, LinkedProperties, PropertyLink}
+import connectors._
 import models.Property
 import org.joda.time.DateTime
 import serialization.JsonFormats._
@@ -30,12 +30,13 @@ class PropertyLinkConnector(http: HttpGet with HttpPut with HttpPost)(implicit e
   lazy val baseUrl: String = baseUrl("property-representations") + s"/property-linking"
 
   def linkToProperty(property: Property, userId: String,
-                     capacityDeclaration: CapacityDeclaration, submissionId: String, basis: LinkBasis)
+                     capacityDeclaration: CapacityDeclaration, submissionId: String, basis: LinkBasis,
+                     fileName: String, fileType: String)
                     (implicit hc: HeaderCarrier): Future[Unit] = {
     val url = baseUrl + s"/property-links/${property.uarn}/$userId/$submissionId"
-    val request = PropertyLink(property.uarn, userId, capacityDeclaration,
-      DateTime.now, basis, property.specialCategoryCode, property.description, property.bulkClassIndicator  )
-    http.POST[PropertyLink, HttpResponse](s"$url", request) map { _ => () }
+    val request = PropertyLinkRequest(property.uarn, userId, capacityDeclaration,
+      DateTime.now, basis, property.specialCategoryCode, property.description, property.bulkClassIndicator, fileName, fileType )
+    http.POST[PropertyLinkRequest, HttpResponse](s"$url", request) map { _ => () }
   }
 
   def linkedProperties(id: String)(implicit hc: HeaderCarrier): Future[LinkedProperties] = {

--- a/app/controllers/SelfCertification.scala
+++ b/app/controllers/SelfCertification.scala
@@ -49,7 +49,7 @@ object SelfCertification extends PropertyLinkingController {
   private def link(request: LinkingSessionRequest[_])(implicit hc: HeaderCarrier) =
     connector.linkToProperty(request.ses.claimedProperty, request.groupId,
       request.ses.declaration.getOrElse(throw new Exception("No declaration")),
-      java.util.UUID.randomUUID.toString, SelfCertifyFlag
+      java.util.UUID.randomUUID.toString, SelfCertifyFlag, "FIXME", "FIXME"
     )
 
   def linkAuthorised() = withLinkingSession { implicit request =>

--- a/app/models/EvidenceType.scala
+++ b/app/models/EvidenceType.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+sealed trait EvidenceType extends NamedEnum {
+  val name: String
+  val key = "evidenceType"
+  override def toString = name
+}
+
+case object Lease extends EvidenceType {
+  val name = "lease"
+}
+
+case object License extends EvidenceType {
+  val name = "license"
+}
+
+case object ServiceCharge extends EvidenceType {
+  val name = "serviceCharge"
+}
+
+case object StampDutyLandTaxForm extends EvidenceType {
+  val name = "stampDutyLandTaxForm"
+}
+
+case object WaterRateDemand extends EvidenceType {
+  val name = "waterRateDemand"
+}
+
+case object OtherUtilityBill extends EvidenceType {
+  val name = "otherUtilityBill"
+}
+
+case object RatesBillType extends EvidenceType {
+  val name = "ratesBill"
+}
+
+object EvidenceType extends NamedEnumSupport[EvidenceType] {
+  override def all: List[EvidenceType] = List(
+    Lease, License, ServiceCharge, StampDutyLandTaxForm,
+    WaterRateDemand, OtherUtilityBill, RatesBillType)
+}

--- a/app/serialization/JsonFormats.scala
+++ b/app/serialization/JsonFormats.scala
@@ -30,6 +30,7 @@ object JsonFormats {
   implicit val capacityTypeFormat = EnumFormat(CapacityType)
   implicit val capacityFormat = Json.format[CapacityDeclaration]
   implicit val requestFlag = EnumFormat(LinkBasis)
+  implicit val propertyLinkRequest = Json.format[PropertyLinkRequest]
   implicit val propertyLink = Json.format[PropertyLink]
   implicit val linkedProperties = Json.format[LinkedProperties]
   implicit val sessionFormat = Json.format[LinkingSession]

--- a/app/views/helpers/inputSelect.scala.html
+++ b/app/views/helpers/inputSelect.scala.html
@@ -1,0 +1,34 @@
+@***********************************
+
+Example usage:
+    @inputSelect(
+    field = model.form("bulkClassIndicator"),
+    Seq(("value-1", "text-value-1"),("value-2", "text-value-2"),("value-3", "text-value-3")),
+    true,
+    '_label -> "the label",
+    '_emptyValueText -> "Select a value",
+    '_labelClass -> "visuallyhidden",
+    '_selectClass -> "form-control"
+    )
+
+To do: errors
+
+***********************************@
+
+
+
+@import helper._
+
+@(field: play.api.data.Field, options: Seq[String], displayEmptyValue: Boolean, args: Seq[(Symbol,Any)])(implicit messages: Messages, requestHeader: RequestHeader)
+
+@input(field, args.map{ x => if(x._2 == '_label) '_name -> x._2 else x }:_*) { (id, name, value, htmlArgs) =>
+    <select id="@(id)" name="@(id)" class="@{args.toMap.get('_selectClass)}">
+        @if(displayEmptyValue) {
+            <option>@{args.toMap.get('_emptyValueText)}</option>
+        }
+        @options.map { v =>
+            <option id="@(id)-@{v.replaceAll(" ", "-")}" value="@v" @if(value.exists(_.toLowerCase == v)){ selected } >@Messages(s"$id.${v.replaceAll(" ", "")}")</option>
+        }
+    </select>
+
+}

--- a/app/views/uploadEvidence/show.scala.html
+++ b/app/views/uploadEvidence/show.scala.html
@@ -33,12 +33,32 @@
                         )
                         <div id="evidenceFileUpload" data-toggle-hidden style="display: none;" class="form-group">
                             <div class="form-label-bold">@Messages("evidence.label")</div>
+                            <div>
                             <span class="">@Messages("evidence.label.1")</span>
-                            @inputFileMulti(
-                                field = model.form("evidence"),
-                                '_label -> "",
-                                '_labelClass -> "form-label-bold"
-                            )
+
+                                <div >
+                                    <div class="column-half">
+                                        @inputFile(
+                                            field = model.form("evidence"),
+                                            '_label -> "",
+                                            '_labelClass -> "form-label-bold"
+                                        )
+                                    </div>
+                                    <div class="column-half">
+                                        @inputSelect(
+                                            field = model.form("evidenceType"),
+                                            options = EvidenceType.options,
+                                            displayEmptyValue=false,
+                                            args = Seq(
+                                                '_label -> Messages("evidenceType.label"),
+                                                '_labelClass -> "form-label-bold",
+                                                '_error -> model.form("evidenceType").error
+                                            )
+                                        )
+                                    </div>
+
+                                </div>
+                            </div>
                         </div>
                     </fieldset>
 

--- a/conf/messages
+++ b/conf/messages
@@ -163,6 +163,15 @@ uploadEvidence.show.title=Submit further proof
 hasEvidence.label=You must provide further proof to show you have a valid connection to the property.
 hasEvidence.doeshaveevidence=I have further proof
 hasEvidence.doesnothaveevidence=I do not have any more proof
+evidenceType.label=Type of evidence
+evidenceType.lease=Lease
+evidenceType.license=License
+evidenceType.serviceCharge=Service charge
+evidenceType.stampDutyLandTaxForm=Stamp duty and land tax form
+evidenceType.waterRateDemand=Water rate demand
+evidenceType.otherUtilityBill=Other utility bill
+evidenceType.ratesBill=Rates bill
+
 evidence.label=Please upload evidence so that we can verify your link to the property.
 evidence.label.1=!File types must be JPEG, PDF or Word. The maximum file size is 5MB. The maximum total file size is 20MB
 error.evidenceUploadFiles=Only 3 files may be uploaded
@@ -171,7 +180,7 @@ uploadEvidence.show.button=Continue
 uploadEvidence.evidenceUploaded.title=Evidence successfully uploaded
 uploadEvidence.evidenceUploaded.message=Thank you for your request which has been submitted to the Valuation Office Agency.
 uploadEvidence.noEvidenceUploaded.title=No evidence provided
-uploadEvidence.noEvidenceUploaded.message=Thank you for your request which has been submitted to the Valuation Office Agency.
+uploadEvidence.noEvidenceUploaded.message=You need to call us!!!
 uploadEvidence.noEvidenceUploaded.home.link=Manage your properties
 
 #LINK ERRORS

--- a/test/controllers/UploadEvidenceSpec.scala
+++ b/test/controllers/UploadEvidenceSpec.scala
@@ -50,7 +50,7 @@ class UploadEvidenceSpec extends ControllerSpec with MockitoSugar {
     status(res) mustBe OK
     val page = HtmlPage(Jsoup.parse(contentAsString(res)))
     page.mustContainRadioSelect("hasevidence", Seq("doeshaveevidence", "doesnothaveevidence"))
-    page.mustContainMultiFileInput("evidence")
+    page.mustContainFileInput("evidence")
   }
 
   it must "redirect to the evidence-submitted page if some evidence  has been uploaded" in {
@@ -61,7 +61,10 @@ class UploadEvidenceSpec extends ControllerSpec with MockitoSugar {
     val req = FakeRequest(Helpers.POST, "/property-linking/upload-evidence")
       .withMultipartFormDataBody(
         MultipartFormData(
-          dataParts = Map("hasEvidence" -> Seq(DoesHaveEvidence.name)),
+          dataParts = Map(
+            "hasEvidence" -> Seq(DoesHaveEvidence.name),
+            "evidenceType" -> Seq(OtherUtilityBill.name)
+          ),
           files = Seq(
             FilePart("evidence", path, None, tmpFile)
           ),
@@ -78,7 +81,10 @@ class UploadEvidenceSpec extends ControllerSpec with MockitoSugar {
     val req = FakeRequest(Helpers.POST, "/property-linking/upload-evidence")
       .withMultipartFormDataBody(
         MultipartFormData(
-          dataParts = Map("hasEvidence" -> Seq(DoesHaveEvidence.name)),
+          dataParts = Map(
+            "hasEvidence" -> Seq(DoesHaveEvidence.name),
+            "evidenceType" -> Seq(OtherUtilityBill.name)
+          ),
           files = Seq(),
           badParts = Seq.empty
         )
@@ -96,7 +102,10 @@ class UploadEvidenceSpec extends ControllerSpec with MockitoSugar {
     val req = FakeRequest(Helpers.POST, "/property-linking/upload-evidence")
       .withMultipartFormDataBody(
         MultipartFormData(
-          dataParts = Map("hasEvidence" -> Seq(DoesNotHaveEvidence.name)), 
+          dataParts = Map(
+            "hasEvidence" -> Seq(DoesNotHaveEvidence.name),
+            "evidenceType" -> Seq(OtherUtilityBill.name)
+          ),
           files = Seq(),
           badParts = Seq.empty
         )

--- a/test/forms/EvidenceUploadForm.scala
+++ b/test/forms/EvidenceUploadForm.scala
@@ -17,7 +17,7 @@
 package forms
 
 import controllers.{UploadEvidence, UploadedEvidence}
-import models.{DoesHaveEvidence, HasEvidence}
+import models._
 import org.scalatest.{FlatSpec, MustMatchers}
 import utils.FormBindingVerification._
 
@@ -27,7 +27,7 @@ class EvidenceUploadForm extends FlatSpec with MustMatchers {
   behavior of "Evidence upload form"
 
   it should "bind to valid data" in {
-    mustBindTo(form, validData, UploadedEvidence(DoesHaveEvidence))
+    mustBindTo(form, validData, UploadedEvidence(DoesHaveEvidence, OtherUtilityBill))
   }
 
   it should "mandate a response to has evidence" in {
@@ -40,6 +40,6 @@ class EvidenceUploadForm extends FlatSpec with MustMatchers {
 
   object TestData {
     val form = UploadEvidence.form
-    val validData = Map("hasEvidence" -> DoesHaveEvidence.name)
+    val validData = Map("hasEvidence" -> DoesHaveEvidence.name, "evidenceType" -> OtherUtilityBill.name)
   }
 }

--- a/test/utils/HtmlPage.scala
+++ b/test/utils/HtmlPage.scala
@@ -26,8 +26,8 @@ case class HtmlPage(html: Document) extends MustMatchers with AppendedClues {
   type FieldName = String
   type Message = String
 
-  def mustContainMultiFileInput(id: String) {
-    mustContain1(s"input#$id[type=file][multiple]")
+  def mustContainFileInput(id: String) {
+    mustContain1(s"input#$id[type=file]")
   }
 
   def mustContainSuccessSummary(msg: String) {

--- a/test/utils/StubPropertyLinkConnector.scala
+++ b/test/utils/StubPropertyLinkConnector.scala
@@ -30,7 +30,9 @@ class StubPropertyLinkConnector extends PropertyLinkConnector(StubHttp) {
   override def linkToProperty(property: Property,
                               userId: String,
                               capacityDeclaration: CapacityDeclaration,
-                              submissionId: String, flag:LinkBasis)(implicit hc: HeaderCarrier)= {
+                              submissionId: String, flag:LinkBasis,
+                              fileName: String, fileType: String
+                             )(implicit hc: HeaderCarrier)= {
     Future.successful( () )
   }
 


### PR DESCRIPTION
upload evidence page has a EvidenceType dropdown list
sending filename and filetype to backend when submitting a linking journey
only one other evidence can be uploaded
no submission is sent if a user has no  evidence to upload