### PR TITLE
No evidence submission

### DIFF
--- a/app/controllers/UploadEvidence.scala
+++ b/app/controllers/UploadEvidence.scala
@@ -86,15 +86,17 @@ class UploadEvidence @Inject()(val fileUploadConnector: FileUpload) extends Prop
   def evidenceUploaded() = withLinkingSession { implicit request =>
     fileUploadConnector.closeEnvelope(request.ses.envelopeId).flatMap(_ =>
       Wiring().sessionRepository.remove().map(_ =>
-        Ok(views.html.linkingRequestSubmitted(RequestSubmittedVM(request.ses.claimedProperty.address)))
+        Ok(views.html.linkingRequestSubmitted(RequestSubmittedVM(request.ses.claimedProperty.address, request.ses.submissionId)))
       )
     )
   }
 
   def noEvidenceUploaded(refId: String) = withLinkingSession { implicit request =>
-    fileUploadConnector.closeEnvelope(request.ses.envelopeId).flatMap(_ =>
-      Wiring().sessionRepository.remove().map(_ =>
-        Ok(views.html.uploadEvidence.noEvidenceUploaded(refId))
+    requestLink(NoEvidenceFlag, None).flatMap( _=>
+      fileUploadConnector.closeEnvelope(request.ses.envelopeId).flatMap(_ =>
+        Wiring().sessionRepository.remove().map(_ =>
+          Ok(views.html.linkingRequestSubmitted(RequestSubmittedVM(request.ses.claimedProperty.address, request.ses.submissionId)))
+        )
       )
     )
   }
@@ -117,4 +119,4 @@ case object FilesMissing extends EvidenceUploadResult
 
 case object FilesUploadFailed extends EvidenceUploadResult
 
-case class RequestSubmittedVM(address: PropertyAddress)
+case class RequestSubmittedVM(address: PropertyAddress, refId: String)

--- a/app/controllers/UploadRatesBill.scala
+++ b/app/controllers/UploadRatesBill.scala
@@ -79,7 +79,7 @@ class UploadRatesBill @Inject()(val fileUploadConnector: FileUpload) extends Pro
   def ratesBillUploaded() = withLinkingSession { implicit request =>
     fileUploadConnector.closeEnvelope(request.ses.envelopeId).flatMap(_ =>
       sessionRepository.remove().map(_ =>
-        Ok(views.html.linkingRequestSubmitted(RequestSubmittedVM(request.ses.claimedProperty.address)))
+        Ok(views.html.linkingRequestSubmitted(RequestSubmittedVM(request.ses.claimedProperty.address, request.ses.submissionId)))
       )
     )
   }

--- a/app/views/linkingRequestSubmitted.scala.html
+++ b/app/views/linkingRequestSubmitted.scala.html
@@ -13,6 +13,8 @@
                     <span class="heading-confirmation-normal">@Messages("linkingRequestSubmitted.title1")</span>
                     <div class="margin-bottom-10 margin-top-10">@model.address.toString</div>
                     <span class="heading-confirmation-normal">@Messages("linkingRequestSubmitted.title2")</span>
+                    <span class="heading-confirmation-normal">@Messages("linkingRequestSubmitted.title3")</span>
+                    <div class="margin-bottom-10 margin-top-10">@model.refId</div>
                 </h1>
 
                 <h2 class="heading-medium">@Messages("heading.whatNext")</h2>

--- a/app/views/uploadEvidence/show.scala.html
+++ b/app/views/uploadEvidence/show.scala.html
@@ -4,7 +4,7 @@
 @(model: UploadEvidenceVM)(implicit request: Request[_], messages: Messages)
 
 
-@main_template(title = Messages("uploadEvidence.show.title")) {
+@main_template(title = Messages("uploadEvidence.show.title"), bottomBackLink = true, topBackLink = true) {
 
 
     @form(routes.UploadEvidence.submit(), 'enctype -> "multipart/form-data") {

--- a/app/views/uploadRatesBill/chooseEvidence.scala.html
+++ b/app/views/uploadRatesBill/chooseEvidence.scala.html
@@ -4,7 +4,9 @@
 
 @(f: Form[_])(implicit request: Request[_], messages: Messages)
 
-    @main_template(Messages("chooseEvidence.title")) {
+    @main_template(Messages("chooseEvidence.title"),
+    topBackLink = true,
+    bottomBackLink = true) {
         <div class="grid-row">
             <div class="column-two-thirds">
 

--- a/app/views/uploadRatesBill/show.scala.html
+++ b/app/views/uploadRatesBill/show.scala.html
@@ -3,7 +3,8 @@
 
 @(model: UploadRatesBillVM)(implicit request: Request[_], messages: Messages)
 
-    @main_template(title = Messages("uploadRatesBill.show.title")) {
+    @main_template(title = Messages("uploadRatesBill.show.title"),
+        topBackLink = true, bottomBackLink = true) {
 
         @form(routes.UploadRatesBill.submit(), 'enctype -> "multipart/form-data") {
 

--- a/conf/messages
+++ b/conf/messages
@@ -307,6 +307,7 @@ uploadRatesBill.ratesBillMissing.error=Please select a rates bill
 #LINK REQUEST CONFIRMATION
 linkingRequestSubmitted.title1=We’ve received your request to add
 linkingRequestSubmitted.title2=to your business’s customer record.
+linkingRequestSubmitted.title3=Submission Id:
 linkingRequestSubmitted.message=Thank you for your request to add [address] to your customer record.
 linkingRequestSubmitted.p.1=The property will appear in your dashboard pending VOA approval.
 linkingRequestSubmitted.p.2=If approval is given, the status will change from ‘pending’ to ‘added’.  This may take some time, depending on the nature of your application.

--- a/test/controllers/RatesBillUploadSpec.scala
+++ b/test/controllers/RatesBillUploadSpec.scala
@@ -45,7 +45,8 @@ class RatesBillUploadSpec extends ControllerSpec with MockitoSugar {
       arbitrary[DetailedIndividualAccount].sample.get, arbitrary[GroupAccount].sample.get)
     override lazy val propertyLinkConnector = StubPropertyLinkConnector
     lazy val sessionCache = new VPLSessionCache(StubHttp)
-    override lazy val sessionRepository = new StubLinkingSessionRepository(LinkingSession(property, "envelopeId", "submissionId"), sessionCache)
+    val submissionId = "submissionId"
+    override lazy val sessionRepository = new StubLinkingSessionRepository(LinkingSession(property, "envelopeId", submissionId), sessionCache)
   }
 
   "Upload Rates Bill upload page" must "allow the user to upload some evidence or not" in {
@@ -99,7 +100,8 @@ class RatesBillUploadSpec extends ControllerSpec with MockitoSugar {
     val page = HtmlPage(Jsoup.parse(contentAsString(res)))
     page.mustContainSuccessSummary(s"✔ We’ve received your request to add ${
       TestUploadRatesBill.property.address.lines.mkString(", ")}, ${
-      TestUploadRatesBill.property.address.postcode} to your business’s customer record.")
+      TestUploadRatesBill.property.address.postcode} to your business’s customer record." +
+      s" Submission Id: ${TestUploadRatesBill.submissionId}")
   }
 
   it must "contains a link to the dashboard" in {


### PR DESCRIPTION
- A reference ID is shown once a linking request has been sent.
- A linking request is submitted to the backend if the user has no
evidence to upload.
- Added back buttons on page related to property linking.