### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -23,11 +23,6 @@ play {
 
   filters {
     headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9032 http://localhost:9570 localhost:9000 *.pingdom.net stats.g.doubleclick.net www.google-analytics.com data:"
-
-    csrf.header.bypassHeaders {
-      X-Requested-With = "*"
-      Csrf-Token = "nocheck"
-    }
   }
 
   http {


### PR DESCRIPTION
The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051