### PR TITLE
VTCCA-3857 removed pageheading from components

### DIFF
--- a/app/views/createAccount/registerIndividual.scala.html
+++ b/app/views/createAccount/registerIndividual.scala.html
@@ -131,7 +131,6 @@
                 fieldset = Some(Fieldset(
                 legend = Some(Legend(
                 content = Text(messages("label.dob")),
-                isPageHeading = true,
                 classes = "govuk-fieldset__legend--m"
             ))
             )),

--- a/app/views/createAccount/registerOrganisation.scala.html
+++ b/app/views/createAccount/registerOrganisation.scala.html
@@ -24,6 +24,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 
+
 @this(mainLayout: mainLayout, govukButton: GovukButton, govukDateInput: GovukDateInput, govukInsetText: GovukInsetText, govukDetails: GovukDetails,govukErrorSummary : GovukErrorSummary, govukInput : GovukInput, govukRadios : GovukRadios, formWithCSRF: FormWithCSRF)
 
 @(model: Form[AdminOrganisationAccountDetails], organisationFieldData: FieldData)(implicit request: Request[_], messages: Messages, config: ApplicationConfig)
@@ -134,24 +135,23 @@
                 fieldset = Some(Fieldset(
                                         legend = Some(Legend(
                                         content = Text(messages("enrolment.organisation.individualOrCompany")),
-                                        classes = "govuk-fieldset__legend--m",
-                                        isPageHeading = true
+                                        classes = "govuk-fieldset__legend--m"
                 ))
                 )),
                 errorMessage = model(keys.isAgent).error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*)))),
                 idPrefix = Some("isAgent"),
                 name = "isAgent",
             items = Seq(
-                RadioItem(
-                        content = Text("Yes"),
-                        value = Some("true"),
-                        checked = model.data.get("isAgent").fold(false)(_ == "true")
-                ),
-                RadioItem(
-                        content = Text("No"),
-                        value = Some("false"),
-                        checked = model.data.get("isAgent").fold(true)(_ == "false")
-                )
+                    RadioItem(
+                            content = Text("Yes"),
+                            value = Some("true"),
+                            checked = model.data.get("isAgent").fold(false)(_ == "true")
+                    ),
+                    RadioItem(
+                            content = Text("No"),
+                            value = Some("false"),
+                            checked = model.data.get("isAgent").fold(true)(_ == "false")
+                    )
                 ),
             classes = "govuk-radios--inline"
             ))
@@ -165,7 +165,6 @@
                 fieldset = Some(Fieldset(
                                         legend = Some(Legend(
                                         content = Text(messages("label.dob")),
-                                        isPageHeading = true,
                                         classes = "govuk-fieldset__legend--m"
                 ))
                 )),


### PR DESCRIPTION
VTCCA-3857 updated code so the error summary does not appear at multiple places which was bug from last ticket

Reddy already applied the changes as part of his other ticket and it was already committed however, when i tested it today, it had problems so i managed to fix that.