### PR TITLE
VTCCA-5010 fixed css warning in sass compilation

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -28,8 +28,7 @@
 
 // GOV.UK Frontend (styles, images and fonts)
 
-
-
+@import "../node_modules/govuk-frontend/govuk/base";
 @import "../node_modules/govuk-frontend/govuk/overrides/typography";
 
 // Generic (normalize/reset.css)


### PR DESCRIPTION
See "Import 'base' before importing Sass files from core or overrides layers" in [govuk-frontend v4.0.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.0)