### PR TITLE
VTCCA-5341 updated sbt, sbt-sassify and tests for java 11

### DIFF
--- a/app/utils/Formatters.scala
+++ b/app/utils/Formatters.scala
@@ -21,6 +21,7 @@ import models.{Address, PropertyAddress}
 import java.text.NumberFormat.getCurrencyInstance
 import java.time.{LocalDate, LocalDateTime, LocalTime}
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 object Formatters {
 
@@ -55,7 +56,7 @@ object Formatters {
     date.format(DateTimeFormatter.ofPattern("d M yyyy"))
 
   def formatTime(time: LocalTime): String =
-    time.format(DateTimeFormatter.ofPattern("hh:mma"))
+    time.format(DateTimeFormatter.ofPattern("hh:mma").withLocale(Locale.UK))
 
   def buildQueryParams(name: String, value: Option[String]): String =
     value match { case Some(paramValue) if paramValue != "" => s"&$name=${paramValue.trim}"; case _ => "" }

--- a/app/utils/Formatters.scala
+++ b/app/utils/Formatters.scala
@@ -55,7 +55,7 @@ object Formatters {
     date.format(DateTimeFormatter.ofPattern("d M yyyy"))
 
   def formatTime(time: LocalTime): String =
-    time.format(DateTimeFormatter.ofPattern("hh:mm a"))
+    time.format(DateTimeFormatter.ofPattern("hh:mma"))
 
   def buildQueryParams(name: String, value: Option[String]): String =
     value match { case Some(paramValue) if paramValue != "" => s"&$name=${paramValue.trim}"; case _ => "" }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,11 +11,10 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
-addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.5.1")
+addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 
 addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.2.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "2.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
-

--- a/test/utils/FormattersSpec.scala
+++ b/test/utils/FormattersSpec.scala
@@ -59,7 +59,8 @@ class FormattersSpec extends BaseUnitSpec {
 
   "formatTime" should {
     "format LocalTimes correctly" in {
-      Formatters.formatTime(LocalTime.of(12, 30)) shouldBe "12:30 PM"
+      Formatters.formatTime(LocalTime.of(6, 30)) shouldBe "06:30am"
+      Formatters.formatTime(LocalTime.of(12, 30)) shouldBe "12:30pm"
     }
   }
 

--- a/test/views/errors/TechnicalDifficultiesPageSpec.scala
+++ b/test/views/errors/TechnicalDifficultiesPageSpec.scala
@@ -47,7 +47,7 @@ class TechnicalDifficultiesPageSpec extends BaseUnitSpec with NoMetricsOneAppPer
     }
 
     "display the current time in 12 hour format" in {
-      page should include("Time: 09:30 AM")
+      page should include("Time: 09:30am")
     }
   }
 


### PR DESCRIPTION
I had to update sbt and sbt-sassify for Java 11 compatibility with M1, and sbt 1.6.2 is the platform recommended version.

Java 11 handles loading Locales differently, so the time formatter changed (to GDS standard). I will rerun the PR builder after I've merged the [build-jobs PR](https://github.com/hmrc/build-jobs/pull/12141), at which point the updated tests should pass.