### PR TITLE
VTCCA-7882 replace valuation-frontend /challenge-status-help endpoint with /show-challenge-status-help

### DIFF
--- a/app/views/dvr/tabs/challengeCasesDetailsTab.scala.html
+++ b/app/views/dvr/tabs/challengeCasesDetailsTab.scala.html
@@ -43,7 +43,7 @@
     <strong class="govuk-tag @tagColour(status)">@status</strong>
 @helpIcon(
     visuallyHiddenText = messages("property.details.challenge.status.help", status),
-    helpPageBaseUrl = config.businessRatesValuationFrontendUrl("challenge-status-help"),
+    helpPageBaseUrl = config.businessRatesValuationFrontendUrl("show-challenge-status-help"),
     guidanceElementId = s"dialog-${status.toLowerCase().replaceAll(" ", "-")}"
     )
 }


### PR DESCRIPTION
This PR changes a link to `business-rates-valuation-frontend/challenge-status-help` to `business-rates-valuation-frontend/show-challenge-status-help` as the original link is being removed (https://github.com/hmrc/business-rates-valuation-frontend/pull/508).