### PR TITLE
VTCCA-7839 Remove unused json.encryption config setting

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,8 +45,6 @@ play {
 
 play.http.router = prod.Routes
 
-json.encryption = ${cookie.encryption}
-
 featureFlags {
   ivEnabled = false
   newRegistrationJourneyEnabled = true


### PR DESCRIPTION
Remove deprecated setting as per https://github.com/hmrc/crypto/blob/811a0ed8af6cdffec79403ab96f37506c338c106/README.md?plain=1#L185