### PR TITLE
VTCCA-8568 Add "cannot challenge" reason messages

### DIFF
--- a/app/views/dvr/cannotRaiseChallenge.scala.html
+++ b/app/views/dvr/cannotRaiseChallenge.scala.html
@@ -22,6 +22,15 @@
 
 @(model: CanChallengeResponse, address: String, localAuth: String, homePageUrl: String, authorisationId: Long, backLinkUrl: String)(implicit request: Request[_], messages: Messages, config: ApplicationConfig)
 
+@challengeReason = @{
+    model.reasonCode
+      .map(code => s"cannotRaiseChallenge.reason.${code.toUpperCase}")
+      .filter(key => messages.isDefinedAt(key))
+      .map(key => messages(key))
+      .orElse(model.reason)
+      .getOrElse("")
+}
+
 @layout(
     pageTitle = messages("cannotRaiseChallenge.title"),
     backUri = Some(backLinkUrl)
@@ -31,7 +40,7 @@
     <div id="cannot-raise-challenge">
         <h1 class="govuk-heading-l">@messages("cannotRaiseChallenge.title")</h1>
 
-        <p class="govuk-body">@model.reason.getOrElse("")</p>
+        <p class="govuk-body" id="reason">@challengeReason</p>
         <p class="govuk-body"> @Html(messages("property.dvr.challenge.error", s"""<a class="govuk-link" href="${config.businessRatesValuationFrontendUrl(s"property-link/valuations/startChallenge?backLinkUrl=$backLinkUrl")}">${messages("property.dvr.challenge.error.link")}</a>"""))</p>
 
 

--- a/conf/messages
+++ b/conf/messages
@@ -1025,6 +1025,14 @@ requestValuation.future.help.help.link.3=Estimate what this property’s busines
 requestValuation.future.help.help.link.4=Business rates relief
 
 cannotRaiseChallenge.title=You cannot challenge this valuation
+cannotRaiseChallenge.reason.C0=You cannot raise a Challenge on a cancelled Check case.
+cannotRaiseChallenge.reason.C6=The Check case hasn’t been completed - you have to wait until 12 months have passed since the Check case was submitted.
+cannotRaiseChallenge.reason.C9=You cannot raise a Challenge case as it has been more than 4 months since the Check Decision notice was sent or the check case was Deemed Complete.
+cannotRaiseChallenge.reason.C10A=You cannot raise a Challenge case as it has been more than 16 months since the Check was submitted.
+cannotRaiseChallenge.reason.C11=You cannot send a Challenge case for valuations on the 2023 rating list before 1 April 2023.
+cannotRaiseChallenge.reason.C12=You cannot send a Challenge case about a change in the local area or a change to the property details for valuations on this rating list if the Check case was not sent from the same rating list.
+cannotRaiseChallenge.reason.C13=You cannot send a Challenge case for this grounds for valuations on the 2017 rating list if the Check case was sent from the 2023 rating list.
+cannotRaiseChallenge.reason.C14=You may still be eligible to raise a Challenge, depending on further information you supply.
 
 property.details.checkcases.p=You can no longer tell us about a change to the property details for valuations in the 2017 rating list period by starting a Check case.
 property.details.checkcases.table.1=Check reference

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -892,6 +892,14 @@ requestValuation.future.help.help.link.3=Amcangyfrif beth all bil ardrethi busne
 requestValuation.future.help.help.link.4=Rhyddhad Ardrethi Busnesau
 
 cannotRaiseChallenge.title=Nid oes modd I chi herio’r prisiad hwn
+cannotRaiseChallenge.reason.C0=Ni allwch godi Her ar achos Gwirio sydd eisoes wedi’i ganslo.
+cannotRaiseChallenge.reason.C6=Nid yw’r achos Gwirio wedi’i gwblhau - mae’n rhaid i chi aros nes bod 12 mis wedi mynd heibio ers i’r achos Gwirio gael ei gyflwyno.
+cannotRaiseChallenge.reason.C9=Ni allwch godi achos Herio gan fod mwy na 4 mis wedi mynd heibio ers i’r hysbysiad Penderfyniad Gwiriad gael ei anfon, neu bod yr achos Gwirio wedi’i Bennu’n Gyflawn.
+cannotRaiseChallenge.reason.C10A=Ni allwch godi achos Herio gan fod mwy nag 16 mis wedi pasio ers cyflwyno’r Gwiriad.
+cannotRaiseChallenge.reason.C11=Ni allwch anfon achos Herio ar gyfer prisiadau ar restr ardrethu 2023 cyn 1 Ebrill 2023.
+cannotRaiseChallenge.reason.C12=Ni allwch anfon achos Herio ynghylch newid yn yr ardal leol neu newid i fanylion yr eiddo ar gyfer prisiadau ar y rhestr ardrethu hon os na anfonwyd yr achos Gwirio o’r un rhestr ardrethu.
+cannotRaiseChallenge.reason.C13=Ni allwch anfon achos Herio ar y seiliau hyn ar gyfer prisiadau ar restr ardrethu 2017 os anfonwyd yr achos Gwirio o restr ardrethu 2023.
+cannotRaiseChallenge.reason.C14=Efallai byddwch dal yn gymwys i godi Her yn ddibynol ar yr wybodaeth bellach a ddarperir gennych.
 
 property.details.checkcases.p=Ni allwch ddweud wrthym bellach am newid i fanylion yr eiddo ar gyfer prisiadau yng nghyfnod rhestr ardrethu 2017 trwy ddechrau achos Gwirio.
 property.details.checkcases.table.1=Cyfeirnod y Gwiriad

--- a/test/controllers/detailedvaluationrequest/DvrControllerSpec.scala
+++ b/test/controllers/detailedvaluationrequest/DvrControllerSpec.scala
@@ -127,7 +127,7 @@ class DvrControllerSpec extends VoaPropertyLinkingSpec {
     when(mockVmvConnector.getPropertyHistory(any())(any()))
       .thenReturn(Future.successful(testPropertyHistory))
 
-    def resultCanChallenge(isOwner: Boolean) =
+    def resultCanChallenge(isOwner: Boolean, req: FakeRequest[AnyContentAsEmpty.type] = request) =
       controller.canChallenge(
         plSubmissionId = plSubmissionId,
         assessmentRef = assessmentRef,
@@ -136,7 +136,7 @@ class DvrControllerSpec extends VoaPropertyLinkingSpec {
         uarn = uarn,
         isOwner = isOwner,
         listYear = listYear
-      )(request)
+      )(req)
   }
 
   "can Challenge for IP" should "redirect to challenge advice page when canChallenge return None" in new CanChallengeSetup {
@@ -269,6 +269,36 @@ class DvrControllerSpec extends VoaPropertyLinkingSpec {
     status(result) shouldBe OK
     contentAsString(result) should include("Fallback reason 123")
     contentAsString(result) should not include "cannotRaiseChallenge.reason.C99"
+  }
+
+  "Welsh cannot raise challenge page" should "show the Welsh message mapped from the reasonCode" in new CanChallengeSetup {
+
+    val testCanChallengeResponse =
+      canChallengeResponse.copy(result = false, reasonCode = Some("C0"), reason = Some("RAW-MODERNISED-TEXT"))
+
+    when(mockPropertyLinkConnector.canChallenge(any(), any(), any(), any())(any()))
+      .thenReturn(Future.successful(Some(testCanChallengeResponse)))
+
+    val result = resultCanChallenge(true, welshFakeRequest)
+
+    status(result) shouldBe OK
+    contentAsString(result) should include("Ni allwch godi Her ar achos Gwirio sydd eisoes wedi’i ganslo.")
+    contentAsString(result) should not include "RAW-MODERNISED-TEXT"
+  }
+
+  "cannot raise challenge page" should "show the message mapped from the reasonCode when reasonCode is lowercase" in new CanChallengeSetup {
+
+    val testCanChallengeResponse =
+      canChallengeResponse.copy(result = false, reasonCode = Some("c0"), reason = Some("RAW-MODERNISED-TEXT"))
+
+    when(mockPropertyLinkConnector.canChallenge(any(), any(), any(), any())(any()))
+      .thenReturn(Future.successful(Some(testCanChallengeResponse)))
+
+    val result = resultCanChallenge(true)
+
+    status(result) shouldBe OK
+    contentAsString(result) should include("You cannot raise a Challenge on a cancelled Check case.")
+    contentAsString(result) should not include "RAW-MODERNISED-TEXT"
   }
 
   "current valuation" should "return 200 OK and have the correct caption" in new Setup {

--- a/test/controllers/detailedvaluationrequest/DvrControllerSpec.scala
+++ b/test/controllers/detailedvaluationrequest/DvrControllerSpec.scala
@@ -252,7 +252,7 @@ class DvrControllerSpec extends VoaPropertyLinkingSpec {
     val result = resultCanChallenge(true)
 
     status(result) shouldBe OK
-    contentAsString(result)      should include("You cannot raise a Challenge on a cancelled Check case.")
+    contentAsString(result) should include("You cannot raise a Challenge on a cancelled Check case.")
     contentAsString(result) should not include "RAW-MODERNISED-TEXT"
   }
 
@@ -267,7 +267,7 @@ class DvrControllerSpec extends VoaPropertyLinkingSpec {
     val result = resultCanChallenge(true)
 
     status(result) shouldBe OK
-    contentAsString(result)      should include("Fallback reason 123")
+    contentAsString(result) should include("Fallback reason 123")
     contentAsString(result) should not include "cannotRaiseChallenge.reason.C99"
   }
 

--- a/test/controllers/detailedvaluationrequest/DvrControllerSpec.scala
+++ b/test/controllers/detailedvaluationrequest/DvrControllerSpec.scala
@@ -241,6 +241,36 @@ class DvrControllerSpec extends VoaPropertyLinkingSpec {
     )
   }
 
+  "cannot raise challenge page" should "show the message mapped from the reasonCode, not the raw Modernised reason" in new CanChallengeSetup {
+
+    val testCanChallengeResponse =
+      canChallengeResponse.copy(result = false, reasonCode = Some("C0"), reason = Some("RAW-MODERNISED-TEXT"))
+
+    when(mockPropertyLinkConnector.canChallenge(any(), any(), any(), any())(any()))
+      .thenReturn(Future.successful(Some(testCanChallengeResponse)))
+
+    val result = resultCanChallenge(true)
+
+    status(result) shouldBe OK
+    contentAsString(result)      should include("You cannot raise a Challenge on a cancelled Check case.")
+    contentAsString(result) should not include "RAW-MODERNISED-TEXT"
+  }
+
+  "cannot raise challenge page" should "fall back to the Modernised reason when the reasonCode has no matching message" in new CanChallengeSetup {
+
+    val testCanChallengeResponse =
+      canChallengeResponse.copy(result = false, reasonCode = Some("C99"), reason = Some("Fallback reason 123"))
+
+    when(mockPropertyLinkConnector.canChallenge(any(), any(), any(), any())(any()))
+      .thenReturn(Future.successful(Some(testCanChallengeResponse)))
+
+    val result = resultCanChallenge(true)
+
+    status(result) shouldBe OK
+    contentAsString(result)      should include("Fallback reason 123")
+    contentAsString(result) should not include "cannotRaiseChallenge.reason.C99"
+  }
+
   "current valuation" should "return 200 OK and have the correct caption" in new Setup {
 
     val ownerAssessments = assessments.copy(assessments = Seq(apiAssessment(ownerAuthorisation)))


### PR DESCRIPTION
Currently the service presents whatever 'reason' message Modernised provides from `/external-case-management-api/my-organisation/property-links/{propertyLinkSubmissionId}/check-cases/{checkCaseRef}`.

This is brittle because we do not get Welsh messages and we want to control the messaging to the end user.

business-rates-valuation-frontend already does this separate mapping, so in this PR we have simply copy/pasted them over from that project's [conf/messages](https://github.com/hmrc/business-rates-valuation-frontend/blob/83919c6786d2df8c58225b93fc3d7f73b2839c6a/conf/messages#L662) and [conf/messages.cy](https://github.com/hmrc/business-rates-valuation-frontend/blob/83919c6786d2df8c58225b93fc3d7f73b2839c6a/conf/messages.cy#L564).